### PR TITLE
Mozilla Bug 782457: Add support for specifying byte ranges of init and cues metadata

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Matthew Gregan <kinetik@flim.org>
+Steve Workman <sjhworkman@gmail.com>

--- a/include/nestegg/nestegg.h
+++ b/include/nestegg/nestegg.h
@@ -149,9 +149,10 @@ typedef void (* nestegg_log)(nestegg * context, unsigned int severity, char cons
     @param context  Storage for the new nestegg context.  @see nestegg_destroy
     @param io       User supplied IO context.
     @param callback Optional logging callback function pointer.  May be NULL.
+    @param max_offset Optional maximum offset to be read. Set -1 to ignore.
     @retval  0 Success.
     @retval -1 Error. */
-int nestegg_init(nestegg ** context, nestegg_io io, nestegg_log callback);
+int nestegg_init(nestegg ** context, nestegg_io io, nestegg_log callback, int64_t max_offset);
 
 /** Destroy a nestegg context and free associated memory.
     @param context #nestegg context to be freed.  @see nestegg_init */
@@ -179,6 +180,19 @@ int nestegg_tstamp_scale(nestegg * context, uint64_t * scale);
     @retval  0 Success.
     @retval -1 Error. */
 int nestegg_track_count(nestegg * context, unsigned int * tracks);
+
+/** Query the start and end offset for a particular cluster.
+    @param context     Stream context initialized by #nestegg_init.
+    @param cluster_num Zero-based cluster number; order they appear in cues.
+    @param max_offset  Optional maximum offset to be read. Set -1 to ignore.
+    @param start_pos   Starting offset of the cluster. -1 means non-existant.
+    @param end_pos     Starting offset of the cluster. -1 means non-existant or
+                       final cluster.
+    @retval  0 Success.
+    @retval -1 Error. */
+int nestegg_get_cue_point(nestegg * context, unsigned int cluster_num,
+                          int64_t max_offset, int64_t * start_pos,
+                          int64_t * end_pos);
 
 /** Seek @a track to @a tstamp.  Stream seek will terminate at the earliest
     key point in the stream at or before @a tstamp.  Other tracks in the

--- a/src/nestegg.c
+++ b/src/nestegg.c
@@ -961,7 +961,7 @@ ne_read_simple(nestegg * ctx, struct ebml_element_desc * desc, size_t length)
 }
 
 static int
-ne_parse(nestegg * ctx, struct ebml_element_desc * top_level)
+ne_parse(nestegg * ctx, struct ebml_element_desc * top_level, int64_t max_offset)
 {
   int r;
   int64_t * data_offset;
@@ -972,6 +972,11 @@ ne_parse(nestegg * ctx, struct ebml_element_desc * top_level)
     return -1;
 
   for (;;) {
+    if (max_offset > 0 && ne_io_tell(ctx->io) >= max_offset) {
+      /* Reached end of offset allowed for parsing - return gracefully */
+      r = 1;
+      break;
+    }
     r = ne_peek_element(ctx, &id, &size);
     if (r != 1)
       break;
@@ -1398,8 +1403,71 @@ ne_null_log_callback(nestegg * ctx, unsigned int severity, char const * fmt, ...
     return;
 }
 
+static int
+ne_init_cue_points(nestegg * ctx, int64_t max_offset)
+{
+  int r;
+  struct ebml_list_node * node = ctx->segment.cues.cue_point.head;
+  struct seek * found;
+  uint64_t seek_pos, id;
+  struct saved_state state;
+
+  /* If there are no cues loaded, check for cues element in the seek head
+     and load it. */
+  if (!node) {
+    found = ne_find_seek_for_id(ctx->segment.seek_head.head, ID_CUES);
+    if (!found)
+      return -1;
+
+    if (ne_get_uint(found->position, &seek_pos) != 0)
+      return -1;
+
+    /* Save old parser state. */
+    r = ne_ctx_save(ctx, &state);
+    if (r != 0)
+      return -1;
+
+    /* Seek and set up parser state for segment-level element (Cues). */
+    r = ne_io_seek(ctx->io, ctx->segment_offset + seek_pos, NESTEGG_SEEK_SET);
+    if (r != 0)
+      return -1;
+    ctx->last_id = 0;
+    ctx->last_size = 0;
+
+    r = ne_read_element(ctx, &id, NULL);
+    if (r != 1)
+      return -1;
+
+    if (id != ID_CUES)
+      return -1;
+
+    ctx->ancestor = NULL;
+    ne_ctx_push(ctx, ne_top_level_elements, ctx);
+    ne_ctx_push(ctx, ne_segment_elements, &ctx->segment);
+    ne_ctx_push(ctx, ne_cues_elements, &ctx->segment.cues);
+    /* parser will run until end of cues element. */
+    ctx->log(ctx, NESTEGG_LOG_DEBUG, "seek: parsing cue elements");
+    r = ne_parse(ctx, ne_cues_elements, max_offset);
+    while (ctx->ancestor)
+      ne_ctx_pop(ctx);
+
+    /* Reset parser state to original state and seek back to old position. */
+    if (ne_ctx_restore(ctx, &state) != 0)
+      return -1;
+
+    if (r < 0)
+      return -1;
+
+    node = ctx->segment.cues.cue_point.head;
+    if (!node)
+      return -1;
+  }
+
+  return 0;
+}
+
 int
-nestegg_init(nestegg ** context, nestegg_io io, nestegg_log callback)
+nestegg_init(nestegg ** context, nestegg_io io, nestegg_log callback, int64_t max_offset)
 {
   int r;
   uint64_t id, version, docversion;
@@ -1435,7 +1503,7 @@ nestegg_init(nestegg ** context, nestegg_io io, nestegg_log callback)
 
   ne_ctx_push(ctx, ne_top_level_elements, ctx);
 
-  r = ne_parse(ctx, NULL);
+  r = ne_parse(ctx, NULL, max_offset);
 
   if (r != 1) {
     nestegg_destroy(ctx);
@@ -1521,60 +1589,83 @@ nestegg_track_count(nestegg * ctx, unsigned int * tracks)
 }
 
 int
+nestegg_get_cue_point(nestegg * ctx, unsigned int cluster_num, int64_t max_offset,
+                      int64_t * start_pos, int64_t * end_pos)
+{
+  int range_obtained = 0;
+  unsigned int cluster_count = 0;
+  struct cue_point * cue_point;
+  struct cue_track_positions * pos;
+  uint64_t seek_pos, t;
+  struct ebml_list_node * cues_node = ctx->segment.cues.cue_point.head;
+  struct ebml_list_node * cue_pos_node = NULL;
+  unsigned int track = 0, track_count = 0;
+
+  if (!start_pos || !end_pos)
+    return -1;
+
+  /* Initialise return values */
+  *start_pos = -1;
+  *end_pos   = -1;
+
+  if (!cues_node) {
+    ne_init_cue_points(ctx, max_offset);
+    cues_node = ctx->segment.cues.cue_point.head;
+    /* Verify cues have been added to context. */
+    if (!cues_node)
+      return -1;
+  }
+
+  nestegg_track_count(ctx, &track_count);
+
+  while (cues_node && !range_obtained) {
+    assert(cues_node->id == ID_CUE_POINT);
+    cue_point = cues_node->data;
+    cue_pos_node = cue_point->cue_track_positions.head;
+    while (cue_pos_node) {
+      assert(cue_pos_node->id == ID_CUE_TRACK_POSITIONS);
+      pos = cue_pos_node->data;
+      for (track = 0; track < track_count; track++) {
+        if (ne_get_uint(pos->track, &t) == 0 && t - 1 == track) {
+          if (ne_get_uint(pos->cluster_position, &seek_pos) != 0)
+            return -1;
+          if (cluster_count == cluster_num) {
+            *start_pos = ctx->segment_offset+seek_pos;
+          } else if (cluster_count == cluster_num+1) {
+            *end_pos = (ctx->segment_offset+seek_pos)-1;
+            range_obtained = 1;
+            break;
+          }
+          cluster_count++;
+        }
+      }
+      cue_pos_node = cue_pos_node->next;
+    }
+    cues_node = cues_node->next;
+  }
+
+  return 0;
+}
+
+int
 nestegg_track_seek(nestegg * ctx, unsigned int track, uint64_t tstamp)
 {
   int r;
   struct cue_point * cue_point;
   struct cue_track_positions * pos;
-  struct saved_state state;
-  struct seek * found;
-  uint64_t seek_pos, tc_scale, t, id;
+  uint64_t seek_pos, tc_scale, t;
   struct ebml_list_node * node = ctx->segment.cues.cue_point.head;
 
   /* If there are no cues loaded, check for cues element in the seek head
      and load it. */
   if (!node) {
-    found = ne_find_seek_for_id(ctx->segment.seek_head.head, ID_CUES);
-    if (!found)
-      return -1;
-
-    if (ne_get_uint(found->position, &seek_pos) != 0)
-      return -1;
-
-    /* Save old parser state. */
-    r = ne_ctx_save(ctx, &state);
+    r = ne_init_cue_points(ctx, -1);
     if (r != 0)
       return -1;
 
-    /* Seek and set up parser state for segment-level element (Cues). */
-    r = ne_io_seek(ctx->io, ctx->segment_offset + seek_pos, NESTEGG_SEEK_SET);
-    if (r != 0)
-      return -1;
-    ctx->last_id = 0;
-    ctx->last_size = 0;
-
-    r = ne_read_element(ctx, &id, NULL);
-    if (r != 1)
-      return -1;
-
-    if (id != ID_CUES)
-      return -1;
-
-    ctx->ancestor = NULL;
-    ne_ctx_push(ctx, ne_top_level_elements, ctx);
-    ne_ctx_push(ctx, ne_segment_elements, &ctx->segment);
-    ne_ctx_push(ctx, ne_cues_elements, &ctx->segment.cues);
-    /* Parser will run until end of cues element. */
-    ctx->log(ctx, NESTEGG_LOG_DEBUG, "seek: parsing cue elements");
-    r = ne_parse(ctx, ne_cues_elements);
-    while (ctx->ancestor)
-      ne_ctx_pop(ctx);
-
-    /* Reset parser state to original state and seek back to old position. */
-    if (ne_ctx_restore(ctx, &state) != 0)
-      return -1;
-
-    if (r < 0)
+    /* Check cues were loaded. */
+    node = ctx->segment.cues.cue_point.head;
+    if (!node)
       return -1;
   }
 
@@ -1612,7 +1703,7 @@ nestegg_track_seek(nestegg * ctx, unsigned int track, uint64_t tstamp)
   ne_ctx_push(ctx, ne_top_level_elements, ctx);
   ne_ctx_push(ctx, ne_segment_elements, &ctx->segment);
   ctx->log(ctx, NESTEGG_LOG_DEBUG, "seek: parsing cluster elements");
-  r = ne_parse(ctx, NULL);
+  r = ne_parse(ctx, NULL, -1);
   if (r != 1)
     return -1;
 
@@ -1859,7 +1950,7 @@ nestegg_read_packet(nestegg * ctx, nestegg_packet ** pkt)
       return r;
     }
 
-    r =  ne_parse(ctx, NULL);
+    r =  ne_parse(ctx, NULL, -1);
     if (r != 1)
       return r;
   }

--- a/test/test.c
+++ b/test/test.c
@@ -102,7 +102,7 @@ main(int argc, char * argv[])
   io.userdata = fp;
 
   ctx = NULL;
-  r = nestegg_init(&ctx, io, log_callback);
+  r = nestegg_init(&ctx, io, log_callback, -1);
   if (r != 0)
     return EXIT_FAILURE;
 


### PR DESCRIPTION
For the DASH-WebM On Demand profile, it is necessary to preload initialization information and cues metadata before starting cluster downloads. This requires some changes in nestegg to deal with specific init and cues byte ranges.

Background: In this DASH profile, stream switching is supposed to happen between clusters. Cluster offsets are not provided in the DASH manifest, but are instead to be read from the video files themselves.
-- Note that byte ranges for init and cues data ARE to be supplied in the DASH manifest, allowing client apps to seek and read the relevant bytes.

http://wiki.webmproject.org/adaptive-streaming/webm-dash-specification
https://bugzilla.mozilla.org/show_bug.cgi?id=782457
