### PR TITLE
Use ne_map_track_number_to_index in nestegg_get_cue_point (from https://bugzilla.mozilla.org/show_bug.cgi?id=832018)

### DIFF
--- a/src/nestegg.c
+++ b/src/nestegg.c
@@ -1637,10 +1637,10 @@ nestegg_get_cue_point(nestegg * ctx, unsigned int cluster_num, int64_t max_offse
   unsigned int cluster_count = 0;
   struct cue_point * cue_point;
   struct cue_track_positions * pos;
-  uint64_t seek_pos, t, tc_scale, time;
+  uint64_t seek_pos, track_number, tc_scale, time;
   struct ebml_list_node * cues_node = ctx->segment.cues.cue_point.head;
   struct ebml_list_node * cue_pos_node = NULL;
-  unsigned int track = 0, track_count = 0;
+  unsigned int track = 0, track_count = 0, track_index;
 
   if (!start_pos || !end_pos || !tstamp)
     return -1;
@@ -1670,7 +1670,13 @@ nestegg_get_cue_point(nestegg * ctx, unsigned int cluster_num, int64_t max_offse
       assert(cue_pos_node->id == ID_CUE_TRACK_POSITIONS);
       pos = cue_pos_node->data;
       for (track = 0; track < track_count; track++) {
-        if (ne_get_uint(pos->track, &t) == 0 && t - 1 == track) {
+        if (ne_get_uint(pos->track, &track_number) != 0)
+          return -1;
+
+        if (ne_map_track_number_to_index(ctx, track_number, &track_index) != 0)
+          return -1;
+
+        if (track_index == track) {
           if (ne_get_uint(pos->cluster_position, &seek_pos) != 0)
             return -1;
           if (cluster_count == cluster_num) {


### PR DESCRIPTION
A track_number to track_id mapping was introduced in Mozilla Bug 804372 for nestegg. The patch did not update nestegg_get_cue_point, so the WebM files with track numbers other than 1 do not work in DASH.

New patch uses ne_map_track_number_to_index in nestegg_get_cue_point.
