### PR TITLE
Cast offsetof to ptrdiff_t before negating

### DIFF
--- a/halloc/src/macros.h
+++ b/halloc/src/macros.h
@@ -20,7 +20,7 @@
 /*
  	restore pointer to the structure by a pointer to its field
  */
-#define structof(p,t,f) ((t*)(- offsetof(t,f) + (char*)(p)))
+#define structof(p,t,f) ((t*)(- (ptrdiff_t) offsetof(t,f) + (char*)(p)))
 
 /*
  *	redefine for the target compiler


### PR DESCRIPTION
The return value of offsetof is of the type size_t, which is unsigned.
When negating an unsigned value, the result still is unsigned.
Therefore, the current calculation might not be totally correct.

This gets rid of the warning "C4146: unarmy minus operator applied to
unsigned type, result still unsigned" in Visual C++. (Tested on
a version as old as Visual C++ 2008, to make sure the ptrdiff_t type
does exist there as well.)
