### PR TITLE
Fix compiler warning.

### DIFF
--- a/src/nestegg.c
+++ b/src/nestegg.c
@@ -968,6 +968,7 @@ ne_read_simple(nestegg * ctx, struct ebml_element_desc * desc, size_t length)
   case TYPE_MASTER:
   case TYPE_UNKNOWN:
     assert(0);
+    r = 0;
     break;
   }
 


### PR DESCRIPTION
clang complains about the use of uninitialized variable in a case that should
never trigger (it is protected by an assert).

Warning: -Wsometimes-uninitialized in libnestegg/src/nestegg.c: variable 'r' is used uninitialized whenever switch case is taken
libnestegg/src/nestegg.c:968:8: warning: variable 'r' is used uninitialized whenever switch case is taken [-Wsometimes-uninitialized]
  case TYPE_MASTER:
       ^~~~~~~~~~~
libnestegg/src/nestegg.c:974:7: note: uninitialized use occurs here
  if (r == 1)
      ^
Warning: -Wsometimes-uninitialized in libnestegg/src/nestegg.c: variable 'r' is used uninitialized whenever switch case is taken
libnestegg/src/nestegg.c:969:8: warning: variable 'r' is used uninitialized whenever switch case is taken [-Wsometimes-uninitialized]
  case TYPE_UNKNOWN:
       ^~~~~~~~~~~~
libnestegg/src/nestegg.c:974:7: note: uninitialized use occurs here
  if (r == 1)
      ^
libnestegg/src/nestegg.c:937:8: note: initialize the variable 'r' to silence this warning
  int r;
       ^
        = 0
