### PR TITLE
add function-y interface for setting halloc allocator

### DIFF
--- a/include/nestegg/nestegg.h
+++ b/include/nestegg/nestegg.h
@@ -363,6 +363,13 @@ int nestegg_has_cues(nestegg * context);
  * @retval 1 The file is a WebM file. */
 int nestegg_sniff(unsigned char const * buffer, size_t length);
 
+/**
+ * Set the underlying allocation function for library allocations.
+ *
+ * @param func The desired function..
+ */
+void nestegg_set_halloc_func(realloc_t func);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/src/nestegg.c
+++ b/src/nestegg.c
@@ -2407,3 +2407,8 @@ nestegg_sniff(unsigned char const * buffer, size_t length)
   return ne_match_webm(io, length);
 }
 
+void
+nestegg_set_halloc_func(realloc_t func)
+{
+  halloc_allocator = func;
+}


### PR DESCRIPTION
Functions can be easier to export across shared library boundaries on
platforms such as Windows.  This patch adds a simple interface for
setting halloc_allocator.

I'd like to use this for https://bugzilla.mozilla.org/show_bug.cgi?id=682216 assuming it can be merged and updating the in-tree copy is no problem.
