### PR TITLE
Fix out-of-tree builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 AUTOMAKE_OPTIONS = foreign 1.11 no-dist-gzip dist-xz subdir-objects
 ACLOCAL_AMFLAGS = -I m4
 
-AM_CPPFLAGS = -I$(top_srcdir)/include -I. -I$(top_srcdir)/halloc
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include -I. -I$(top_srcdir)/halloc
 AM_CFLAGS = -ansi -pedantic -Wall -Wextra -Wno-long-long -Wno-unused-parameter -O2 -g
 
 SUBDIRS = docs


### PR DESCRIPTION
Need to be able to include the generated nestegg-stdint.h file
even if we're building in a separate directory from the source
tree.

https://github.com/kinetiknz/nestegg/issues/28