### PR TITLE
Update nestegg_packet_count doc string

### DIFF
--- a/include/nestegg/nestegg.h
+++ b/include/nestegg/nestegg.h
@@ -332,7 +332,7 @@ int nestegg_packet_duration(nestegg_packet * packet, uint64_t * duration);
 
 /** Query the number of data chunks contained in @a packet.
     @param packet Packet initialized by #nestegg_read_packet.
-    @param count  Storage for the queried timestamp in nanoseconds.
+    @param count  Storage for the queried chunk count.
     @retval  0 Success.
     @retval -1 Error. */
 int nestegg_packet_count(nestegg_packet * packet, unsigned int * count);


### PR DESCRIPTION
The docstring for the count arg to nestegg_packet_count has been updated to better reflect the usage of the argurment.