### PR TITLE
Don't redefine max_align_t if defined by GCC or Clang

### DIFF
--- a/halloc/src/align.h
+++ b/halloc/src/align.h
@@ -22,7 +22,7 @@
  */
 typedef double max_align_t;
 
-#else
+#elif !defined(__CLANG_MAX_ALIGN_T_DEFINED) && !defined(_GCC_MAX_ALIGN_T)
 
 /*
  *	a type with the most strict alignment requirements


### PR DESCRIPTION
Fixes "conflicting types" error when building with `-std=c11` when using GCC or Clang.

See also #26.