### PR TITLE
Make nestegg_read_packet resumable

### DIFF
--- a/include/nestegg/nestegg.h
+++ b/include/nestegg/nestegg.h
@@ -95,7 +95,6 @@ extern "C" {
 
 typedef struct nestegg nestegg;               /**< Opaque handle referencing the stream state. */
 typedef struct nestegg_packet nestegg_packet; /**< Opaque handle referencing a packet of data. */
-typedef struct nestegg_state nestegg_state;   /**< Opaque handle referencing the stream state backup. */
 
 /** User supplied IO context. */
 typedef struct {
@@ -409,25 +408,6 @@ int nestegg_sniff(unsigned char const * buffer, size_t length);
     @retval 0 Failure. realloc_func(p, 0) does not act as free()
     @retval -1 Failure. realloc_func(NULL, 1) failed. */
 int nestegg_set_halloc_func(void * (* realloc_func)(void *, size_t));
-
-/** Save a nestegg context. It is intended to resume a parsing operation.
-    @param context  Stream context initialized by #nestegg_init.
-    @param context  Storage for the new nestegg state backup
-                    @see nestegg_destroy_state.
-    @retval  0 Success.
-    @retval -1 Error. */
-int nestegg_save_state(nestegg * context, nestegg_state ** state);
-
-/** Restore a nestegg state backup allocated with nestegg_save_state
-    @param context  Stream context initialized by #nestegg_init.
-    @param state    State backup to be restored.  @see nestegg_save_state
-                    The state object will be freed upon exit and is no longer
-                    usable. */
-void nestegg_restore_state(nestegg * context, nestegg_state * state);
-
-/** Destroy a nestegg state backup allocated with nestegg_save_state
-    @param state    #nestegg state backup to be freed.  @see nestegg_save_state */
-void nestegg_destroy_state(nestegg_state * state);
 
 #if defined(__cplusplus)
 }

--- a/include/nestegg/nestegg.h
+++ b/include/nestegg/nestegg.h
@@ -298,6 +298,12 @@ int nestegg_track_audio_params(nestegg * context, unsigned int track,
 int nestegg_track_default_duration(nestegg * context, unsigned int track,
                                    uint64_t * duration);
 
+/** Reset parser state to the last valid state before nestegg_read_packet failed.
+    @param context Stream context initialized by #nestegg_init.
+    @retval  0 Success.
+    @retval -1 Error. */
+int nestegg_read_reset(nestegg * context);
+
 /** Read a packet of media data.  A packet consists of one or more chunks of
     data associated with a single track.  nestegg_read_packet should be
     called in a loop while the return value is 1 to drive the stream parser

--- a/include/nestegg/nestegg.h
+++ b/include/nestegg/nestegg.h
@@ -412,7 +412,7 @@ int nestegg_set_halloc_func(void * (* realloc_func)(void *, size_t));
 
 /** Save a nestegg context. It is intended to resume a parsing operation.
     @param context  Stream context initialized by #nestegg_init.
-    @param state    Storage for the new nestegg state backup
+    @param context  Storage for the new nestegg state backup
                     @see nestegg_destroy_state.
     @retval  0 Success.
     @retval -1 Error. */

--- a/src/nestegg.c
+++ b/src/nestegg.c
@@ -176,7 +176,6 @@ struct ebml_type {
   } v;
   enum ebml_type_enum type;
   int read;
-  int64_t offset;
 };
 
 /* EBML Definitions */
@@ -284,6 +283,14 @@ struct list_node {
   unsigned char * data;
 };
 
+struct saved_state {
+  int64_t stream_offset;
+  struct list_node * ancestor;
+  uint64_t last_id;
+  uint64_t last_size;
+  int last_valid;
+};
+
 struct frame {
   unsigned char * data;
   size_t length;
@@ -324,14 +331,6 @@ struct nestegg_packet {
   int64_t reference_block;
   int read_reference_block;
   uint8_t keyframe;
-};
-
-struct nestegg_state {
-  int64_t stream_offset;
-  struct list_node * ancestor;
-  uint64_t last_id;
-  uint64_t last_size;
-  int last_valid;
 };
 
 /* Element Descriptor */
@@ -829,7 +828,7 @@ ne_ctx_pop(nestegg * ctx)
 }
 
 static int
-ne_ctx_save(nestegg * ctx, nestegg_state * s)
+ne_ctx_save(nestegg * ctx, struct saved_state * s)
 {
   s->stream_offset = ne_io_tell(ctx->io);
   if (s->stream_offset < 0)
@@ -842,7 +841,7 @@ ne_ctx_save(nestegg * ctx, nestegg_state * s)
 }
 
 static int
-ne_ctx_restore(nestegg * ctx, nestegg_state * s)
+ne_ctx_restore(nestegg * ctx, struct saved_state * s)
 {
   int r;
 
@@ -959,15 +958,9 @@ ne_read_simple(nestegg * ctx, struct ebml_element_desc * desc, size_t length)
   storage = (struct ebml_type *) (ctx->ancestor->data + desc->offset);
 
   if (storage->read) {
-    ctx->log(ctx, NESTEGG_LOG_DEBUG, "element %llx (%s) already read",
+    ctx->log(ctx, NESTEGG_LOG_DEBUG, "element %llx (%s) already read, skipping",
              desc->id, desc->name);
-    /* We do not need to re-read the element, however we do need to move the IO
-       position back to the original offset */
-    if (storage->offset >= 0) {
-      return ne_io_seek(ctx->io, storage->offset, NESTEGG_SEEK_SET);
-    } else {
-      return 0;
-    }
+    return 0;
   }
 
   storage->type = desc->type;
@@ -996,10 +989,8 @@ ne_read_simple(nestegg * ctx, struct ebml_element_desc * desc, size_t length)
     break;
   }
 
-  if (r == 1) {
-    storage->offset = ne_io_tell(ctx->io);
+  if (r == 1)
     storage->read = 1;
-  }
 
   return r;
 }
@@ -1625,7 +1616,7 @@ ne_init_cue_points(nestegg * ctx, int64_t max_offset)
   struct ebml_list_node * node = ctx->segment.cues.cue_point.head;
   struct seek * found;
   uint64_t seek_pos, id;
-  nestegg_state state;
+  struct saved_state state;
 
   /* If there are no cues loaded, check for cues element in the seek head
      and load it. */
@@ -1898,69 +1889,6 @@ nestegg_destroy(nestegg * ctx)
   ne_pool_destroy(ctx->alloc_pool);
   free(ctx->io);
   free(ctx);
-}
-
-int
-nestegg_save_state(nestegg * ctx, nestegg_state ** state)
-{
-  struct list_node * item;
-  struct nestegg copy;
-  nestegg_state * s;
-
-  s = ne_alloc(sizeof(*s));
-  if (!s) {
-    return -1;
-  }
-
-  if (ne_ctx_save(ctx, s) < 0) {
-    free(s);
-    return -1;
-  }
-
-  copy.ancestor = NULL;
-  item = ctx->ancestor;
-  while (item) {
-    ne_ctx_push(&copy, item->node, item->data);
-    item = item->previous;
-  }
-  /* ancestor now point to the first item of the context stack. */
-  s->ancestor = copy.ancestor;
-  *state = s;
-  return 0;
-}
-
-void
-nestegg_restore_state(nestegg * ctx, nestegg_state * s)
-{
-  struct nestegg copy;
-
-  if (!s->ancestor) {
-    free(s);
-    return;
-  }
-
-  while (ctx->ancestor)
-    ne_ctx_pop(ctx);
-
-  copy.ancestor = s->ancestor;
-  while (copy.ancestor) {
-    ne_ctx_push(ctx, copy.ancestor->node, copy.ancestor->data);
-    ne_ctx_pop(&copy);
-  }
-  s->ancestor = ctx->ancestor;
-  ne_ctx_restore(ctx, s);
-  free(s);
-  return;
-}
-
-void
-nestegg_destroy_state(nestegg_state * state)
-{
-  nestegg ctx;
-  ctx.ancestor = state->ancestor;
-  while (ctx.ancestor)
-    ne_ctx_pop(&ctx);
-  free(state);
 }
 
 int

--- a/test/regress.test
+++ b/test/regress.test
@@ -17,3 +17,12 @@ do_test seek_sub.webm
 do_test bug1200148.webm -l
 do_test dancer1.webm
 do_test dancer1rb.webm
+
+do_test seek.webm -r
+do_test bug603918.webm -r
+do_test detodos.webm -r
+do_test split.webm -r
+do_test demo_short.webm -r
+do_test seek_sub.webm -r
+do_test dancer1.webm -r
+do_test dancer1rb.webm -r


### PR DESCRIPTION
This work is part of BMO #1261900.

Gecko's MSE implementation needs to be able to run nestegg_read_packet
until it hits EOS, producing every packet it can parse, and then restore
the parser state when new data is appended to the stream and resume
parsing from the last valid block.

nestegg_read_reset introduces a way to reset the parser context to the
beginning of the last point before a nestegg_read_packet call returned
EOS.  If the stream then has sufficient data appended to it, a
subsequent call to nestegg_read_packet is then expected to produce the
next packet(s) without producing any previously parsed packets.

Note that this mode requires the caller to carefully manage the EOS
state so that it can distinguish between "fake" EOS and "real" EOS.

Removing the general ne_parse machinery from nestegg_read_packet
significantly reduces the potential state changes to rollback on reset.
The small amount of remaining state is saved with ne_ctx_save and
restored via ne_ctx_restore.