### PR TITLE
Improve test compatibility for MinGW builds.

### DIFF
--- a/test/regress.test
+++ b/test/regress.test
@@ -4,7 +4,7 @@ set -e
 function do_test {
   OUT=`mktemp`
   test/regress "${srcdir}/test/media/$1" $2 > $OUT
-  cmp "${srcdir}/test/media/$1.ok" $OUT
+  diff --strip-trailing-cr "${srcdir}/test/media/$1.ok" $OUT
   rm $OUT
 }
 

--- a/test/sha1.c
+++ b/test/sha1.c
@@ -11,7 +11,7 @@
 # define SHA_BIG_ENDIAN
 #elif defined __LITTLE_ENDIAN__
 /* override */
-#elif defined __BYTE_ORDER
+#elif defined __BYTE_ORDER__
 # if __BYTE_ORDER__ ==  __ORDER_BIG_ENDIAN__
 # define SHA_BIG_ENDIAN
 # endif


### PR DESCRIPTION
Aside from the original commit blurb below, there's also the usage of long long types in format strings. Despite compile time warnings, this appears to work. This looks like it's a known issue, but that at runtime it will work okay: http://mingw.5.n7.nabble.com/snprintf-and-USE-MINGW-ANSI-STDIO-td35399.html. As such, I've left it as is.

---

Looks like there was a typo in endian detection which would cause mingw to try
and import endian.h, which would fail. This typo has been fixed so now the
appropriate preprocessor define will be checked.

Updated the way comparisons are done by the tests to use diff instead of cmp,
which lets line endings be stripped. Previously, line endings differences would
result in failures, even when the rest of the test output matched, this
prevents such failures.