### PR TITLE
Adds support for parsing subsample encryption offsets

### DIFF
--- a/include/nestegg/nestegg.h
+++ b/include/nestegg/nestegg.h
@@ -92,11 +92,10 @@ extern "C" {
 #define NESTEGG_ENCODING_COMPRESSION 0 /**< Content encoding type is compression. */
 #define NESTEGG_ENCODING_ENCRYPTION  1 /**< Content encoding type is encryption. */
 
-#define NESTEGG_PACKET_HAS_SIGNAL_BYTE_FALSE       0 /**< Packet does not have signal byte */
-#define NESTEGG_PACKET_HAS_SIGNAL_BYTE_UNENCRYPTED 1 /**< Packet has signal byte and is unencrypted */
-#define NESTEGG_PACKET_HAS_SIGNAL_BYTE_ENCRYPTED   2 /**< Packet has signal byte and is encrypted */
-#define NESTEGG_PACKET_HAS_SIGNAL_BYTE_UNPARTITIONED 4 /**< Packet has signal byte and is not partitioned */
-#define NESTEGG_PACKET_HAS_SIGNAL_BYTE_PARTITIONED 8 /**< Packet has signal byte and is partitioned */
+#define NESTEGG_PACKET_HAS_SIGNAL_BYTE_FALSE         0 /**< Packet does not have signal byte */
+#define NESTEGG_PACKET_HAS_SIGNAL_BYTE_UNENCRYPTED   1 /**< Packet has signal byte and is unencrypted */
+#define NESTEGG_PACKET_HAS_SIGNAL_BYTE_ENCRYPTED     2 /**< Packet has signal byte and is encrypted */
+#define NESTEGG_PACKET_HAS_SIGNAL_BYTE_PARTITIONED   4 /**< Packet has signal byte and is partitioned */
 
 #define NESTEGG_PACKET_HAS_KEYFRAME_FALSE   0 /**< Packet contains only keyframes. */
 #define NESTEGG_PACKET_HAS_KEYFRAME_TRUE    1 /**< Packet does not contain any keyframes */
@@ -426,19 +425,10 @@ int nestegg_packet_discard_padding(nestegg_packet * packet,
              set, encryption information not read from packet.
     @retval  #NESTEGG_PACKET_HAS_SIGNAL_BYTE_ENCRYPTED Encrypted bit set,
              encryption infomation read from packet.
+    @retval  #NESTEGG_PACKET_HAS_SIGNAL_BYTE_PARTITIONED Partitioned bit set,
+             encryption and parition information read from packet.
     @retval -1 Error.*/
 int nestegg_packet_encryption(nestegg_packet * packet);
-
-/** Query if a packet is partitioned.
-@param packet Packet initialized by #nestegg_read_packet.
-@retval  #NESTEGG_PACKET_HAS_SIGNAL_BYTE_FALSE No signal byte, partition
-information not read from packet.
-@retval  #NESTEGG_PACKET_HAS_SIGNAL_BYTE_UNPARTITIONED Partitioned bit not
-set, partition information not read from packet.
-@retval  #NESTEGG_PACKET_HAS_SIGNAL_BYTE_PARTITIONED Partitioned bit set,
-partition information read from packet.
-@retval -1 Error.*/
-int nestegg_packet_partitioned(nestegg_packet * packet);
 
 /** Query the IV for an encrypted packet. Expects a packet from an encrypted
     track, and will return error if given a packet that has no signal btye.
@@ -461,7 +451,7 @@ The data is owned by the #nestegg_packet packet.
 @retval -1 Error.
 */
 int nestegg_packet_offsets(nestegg_packet * packet,
-                           uint32_t ** partition_offsets,
+                           uint32_t const ** partition_offsets,
                            uint8_t * num_offsets);
 
 /** Returns reference_block given packet

--- a/include/nestegg/nestegg.h
+++ b/include/nestegg/nestegg.h
@@ -95,6 +95,8 @@ extern "C" {
 #define NESTEGG_PACKET_HAS_SIGNAL_BYTE_FALSE       0 /**< Packet does not have signal byte */
 #define NESTEGG_PACKET_HAS_SIGNAL_BYTE_UNENCRYPTED 1 /**< Packet has signal byte and is unencrypted */
 #define NESTEGG_PACKET_HAS_SIGNAL_BYTE_ENCRYPTED   2 /**< Packet has signal byte and is encrypted */
+#define NESTEGG_PACKET_HAS_SIGNAL_BYTE_UNPARTITIONED 4 /**< Packet has signal byte and is not partitioned */
+#define NESTEGG_PACKET_HAS_SIGNAL_BYTE_PARTITIONED 8 /**< Packet has signal byte and is partitioned */
 
 #define NESTEGG_PACKET_HAS_KEYFRAME_FALSE   0 /**< Packet contains only keyframes. */
 #define NESTEGG_PACKET_HAS_KEYFRAME_TRUE    1 /**< Packet does not contain any keyframes */
@@ -427,6 +429,17 @@ int nestegg_packet_discard_padding(nestegg_packet * packet,
     @retval -1 Error.*/
 int nestegg_packet_encryption(nestegg_packet * packet);
 
+/** Query if a packet is partitioned.
+@param packet Packet initialized by #nestegg_read_packet.
+@retval  #NESTEGG_PACKET_HAS_SIGNAL_BYTE_FALSE No signal byte, partition
+information not read from packet.
+@retval  #NESTEGG_PACKET_HAS_SIGNAL_BYTE_UNPARTITIONED Partitioned bit not
+set, partition information not read from packet.
+@retval  #NESTEGG_PACKET_HAS_SIGNAL_BYTE_PARTITIONED Partitioned bit set,
+partition information read from packet.
+@retval -1 Error.*/
+int nestegg_packet_partitioned(nestegg_packet * packet);
+
 /** Query the IV for an encrypted packet. Expects a packet from an encrypted
     track, and will return error if given a packet that has no signal btye.
     @param packet Packet initialized by #nestegg_read_packet.
@@ -438,6 +451,18 @@ int nestegg_packet_encryption(nestegg_packet * packet);
   */
 int nestegg_packet_iv(nestegg_packet * packet, unsigned char const ** iv,
                       size_t * length);
+
+/** Query the packet for offsets.
+@param packet            Packet initialized by #nestegg_read_packet.
+@param partition_offsets Storage for queried offsets.
+@param num_offsets       Length of returned offsets, may be 0.
+The data is owned by the #nestegg_packet packet.
+@retval  0 Success.
+@retval -1 Error.
+*/
+int nestegg_packet_offsets(nestegg_packet * packet,
+                           uint32_t ** partition_offsets,
+                           uint8_t * num_offsets);
 
 /** Returns reference_block given packet
     @param packet          Packet initialized by #nestegg_read_packet.

--- a/src/nestegg.c
+++ b/src/nestegg.c
@@ -164,10 +164,15 @@ enum ebml_type_enum {
 /* Packet Encryption */
 #define SIGNAL_BYTE_SIZE            1
 #define IV_SIZE                     8
+#define NUM_PACKETS_SIZE            1
+#define PACKET_OFFSET_SIZE          4
 
 /* Signal Byte */
 #define PACKET_ENCRYPTED            1
 #define ENCRYPTED_BIT_MASK          (1 << 0)
+
+#define PACKET_PARTITIONED          2
+#define PARTITIONED_BIT_MASK        (1 << 1)
 
 enum vint_mask {
   MASK_NONE,
@@ -335,6 +340,9 @@ struct saved_state {
 };
 
 struct frame_encryption {
+  uint8_t num_partitions;
+  uint32_t* partition_offsets;
+
   unsigned char * iv;
   size_t length;
   uint8_t signal_byte;
@@ -1553,6 +1561,36 @@ ne_read_block(nestegg * ctx, uint64_t block_id, uint64_t block_size, nestegg_pac
         }
         f->frame_encryption->length = IV_SIZE;
         encryption_size = SIGNAL_BYTE_SIZE + IV_SIZE;
+
+        if ((signal_byte & PARTITIONED_BIT_MASK) == PACKET_PARTITIONED) {
+          r = ne_io_read(ctx->io, &f->frame_encryption->num_partitions, NUM_PACKETS_SIZE);
+          if (r != 1) {
+            free(f->frame_encryption->iv);
+            free(f->frame_encryption);
+            free(f);
+            nestegg_free_packet(pkt);
+            return r;
+          }
+          
+          encryption_size += NUM_PACKETS_SIZE + f->frame_encryption->num_partitions * PACKET_OFFSET_SIZE;
+          f->frame_encryption->partition_offsets = ne_alloc(f->frame_encryption->num_partitions * PACKET_OFFSET_SIZE);
+          r = 0;
+          for (i = 0; i < f->frame_encryption->num_partitions; i++) {
+            uint64_t value = 0;
+            r += ne_read_uint(ctx->io, &value, PACKET_OFFSET_SIZE);
+            f->frame_encryption->partition_offsets[i] = (uint32_t)value;
+          }
+
+          /* If any of the partition offsets did not return 1, then fail. */
+          if (r != f->frame_encryption->num_partitions) {
+            free(f->frame_encryption->iv);
+            free(f->frame_encryption);
+            free(f->frame_encryption->partition_offsets);
+            free(f);
+            nestegg_free_packet(pkt);
+            return r;
+          }
+        }
       } else {
         f->frame_encryption->iv = NULL;
         f->frame_encryption->length = 0;
@@ -2862,6 +2900,7 @@ nestegg_free_packet(nestegg_packet * pkt)
     pkt->frame = frame->next;
     if (frame->frame_encryption) {
       free(frame->frame_encryption->iv);
+      free(frame->frame_encryption->partition_offsets);
     }
     free(frame->frame_encryption);
     free(frame->data);
@@ -3005,6 +3044,26 @@ nestegg_packet_encryption(nestegg_packet * pkt)
 }
 
 int
+nestegg_packet_partitioned(nestegg_packet * pkt)
+{
+  struct frame * f = pkt->frame;
+  unsigned char partitioned_bit;
+
+  if (!f->frame_encryption)
+    return NESTEGG_PACKET_HAS_SIGNAL_BYTE_FALSE;
+
+  /* Should never have parsed blocks with both encryption and lacing */
+  assert(f->next == NULL);
+
+  partitioned_bit = f->frame_encryption->signal_byte & PARTITIONED_BIT_MASK;
+
+  if (partitioned_bit != PACKET_PARTITIONED)
+    return NESTEGG_PACKET_HAS_SIGNAL_BYTE_UNPARTITIONED;
+
+  return NESTEGG_PACKET_HAS_SIGNAL_BYTE_PARTITIONED;
+}
+
+int
 nestegg_packet_iv(nestegg_packet * pkt, unsigned char const ** iv, size_t * length)
 {
   struct frame * f = pkt->frame;
@@ -3025,6 +3084,33 @@ nestegg_packet_iv(nestegg_packet * pkt, unsigned char const ** iv, size_t * leng
 
   *iv = f->frame_encryption->iv;
   *length = f->frame_encryption->length;
+  return 0;
+}
+
+int
+nestegg_packet_offsets(nestegg_packet * pkt, uint32_t ** partition_offsets, uint8_t * num_partitions)
+{
+  struct frame * f = pkt->frame;
+  unsigned char encrypted_bit;
+  unsigned char partitioned_bit;
+
+  *partition_offsets = NULL;
+  *num_partitions = 0;
+
+  if (!f->frame_encryption)
+    return -1;
+
+  /* Should never have parsed blocks with both encryption and lacing */
+  assert(f->next == NULL);
+
+  encrypted_bit = f->frame_encryption->signal_byte & ENCRYPTED_BIT_MASK;
+  partitioned_bit = f->frame_encryption->signal_byte & PARTITIONED_BIT_MASK;
+
+  if (encrypted_bit != PACKET_ENCRYPTED && partitioned_bit != PACKET_PARTITIONED)
+    return 0;
+
+  *num_partitions = f->frame_encryption->num_partitions;
+  *partition_offsets = f->frame_encryption->partition_offsets;
   return 0;
 }
 


### PR DESCRIPTION
References:
BMO bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1306477
Spec: https://www.webmproject.org/docs/webm-encryption/#46-subsample-encrypted-block-format
Details: https://storage.googleapis.com/downloads.webmproject.org/docs/vp9/vp-codec-iso-media-file-format-binding-20160516-draft.pdf
