### PR TITLE
Add AV1 codec id

### DIFF
--- a/include/nestegg/nestegg.h
+++ b/include/nestegg/nestegg.h
@@ -71,6 +71,7 @@ extern "C" {
 #define NESTEGG_CODEC_VORBIS  1       /**< Track uses Xiph Vorbis codec. */
 #define NESTEGG_CODEC_VP9     2       /**< Track uses Google On2 VP9 codec. */
 #define NESTEGG_CODEC_OPUS    3       /**< Track uses Xiph Opus codec. */
+#define NESTEGG_CODEC_AV1     4       /**< Track use AOMedia AV1 codec. */
 #define NESTEGG_CODEC_UNKNOWN INT_MAX /**< Track uses unknown codec. */
 
 #define NESTEGG_VIDEO_MONO              0 /**< Track is mono video. */

--- a/src/nestegg.c
+++ b/src/nestegg.c
@@ -154,6 +154,7 @@ enum ebml_type_enum {
 /* Track IDs */
 #define TRACK_ID_VP8                "V_VP8"
 #define TRACK_ID_VP9                "V_VP9"
+#define TRACK_ID_AV1                "V_AV1"
 #define TRACK_ID_VORBIS             "A_VORBIS"
 #define TRACK_ID_OPUS               "A_OPUS"
 
@@ -2369,6 +2370,9 @@ nestegg_track_codec_id(nestegg * ctx, unsigned int track)
 
   if (strcmp(codec_id, TRACK_ID_VP9) == 0)
     return NESTEGG_CODEC_VP9;
+
+  if (strcmp(codec_id, TRACK_ID_AV1) == 0)
+    return NESTEGG_CODEC_AV1;
 
   if (strcmp(codec_id, TRACK_ID_VORBIS) == 0)
     return NESTEGG_CODEC_VORBIS;


### PR DESCRIPTION
The AOMedia AV1 codec reference implementation uses the
'V_AV1' track codec id. Recognize and return this for
clients supporting this codec.