### PR TITLE
Add NESTEGG_CODEC_AV1 to documentation.

### DIFF
--- a/include/nestegg/nestegg.h
+++ b/include/nestegg/nestegg.h
@@ -249,6 +249,7 @@ int nestegg_track_type(nestegg * context, unsigned int track);
     @param track   Zero based track number.
     @retval #NESTEGG_CODEC_VP8     Track codec is VP8.
     @retval #NESTEGG_CODEC_VP9     Track codec is VP9.
+    @retval #NESTEGG_CODEC_AV1     Track codec is AV1.
     @retval #NESTEGG_CODEC_VORBIS  Track codec is Vorbis.
     @retval #NESTEGG_CODEC_OPUS    Track codec is Opus.
     @retval #NESTEGG_CODEC_UNKNOWN Track codec is unknown.


### PR DESCRIPTION
The new codec id can be returned by nestegg_track_codec_id(),
so the documentation should be updated there as well.