### PR TITLE
Correct conversion of unscaled_duration to a uint64_t when unscaled_duration is 0x1p64

### DIFF
--- a/src/nestegg.c
+++ b/src/nestegg.c
@@ -2174,7 +2174,7 @@ nestegg_duration(nestegg * ctx, uint64_t * duration)
     return -1;
 
   if (unscaled_duration != unscaled_duration ||
-      unscaled_duration < 0 || unscaled_duration > (double) UINT64_MAX ||
+      unscaled_duration < 0 || unscaled_duration >= (double) UINT64_MAX ||
       (uint64_t) unscaled_duration > UINT64_MAX / tc_scale)
     return -1;
 


### PR DESCRIPTION
It'd be clearer to check |>= 0x1p64| instead of |>= (double) UINT64_MAX| (which behaves differently under different rounding modes), but that requires C99 functionality only recently added to MSVC.

More context at https://bugzilla.mozilla.org/show_bug.cgi?id=1393284