### PR TITLE
Stop rejecting negative timestamps.

### DIFF
--- a/src/nestegg.c
+++ b/src/nestegg.c
@@ -1550,8 +1550,11 @@ ne_read_block(nestegg * ctx, uint64_t block_id, uint64_t block_size, nestegg_pac
   cluster_tc = ctx->cluster_timecode;
 
   abs_timecode = timecode + cluster_tc;
-  if (abs_timecode < 0)
-    return -1;
+  if (abs_timecode < 0) {
+      /* Ignore the spec and negative timestamps */
+      ctx->log(ctx, NESTEGG_LOG_WARNING, "ignoring negative timecode: %s", abs_timecode);
+      abs_timecode = 0;
+  }
 
   pkt = ne_alloc(sizeof(*pkt));
   if (!pkt)


### PR DESCRIPTION
This change is in opposition to the spec, however there are many invalid WEBMs with negative timestamps that other parsers will play (notably ffmpeg).  Net result is media that plays in Chrome and not in Firefox.

While https://bugzilla.mozilla.org/show_bug.cgi?id=868797#c18 states that "we never supported this because it's invalid", the phrasing is past tense and the bug is still open, which I'm taking as a signal that a patch that ignores negative timestamps may be accepted.