### PR TITLE
Avoid clang warning about uninitialized data_size

### DIFF
--- a/src/nestegg.c
+++ b/src/nestegg.c
@@ -1689,6 +1689,7 @@ ne_read_block_additions(nestegg * ctx, uint64_t block_size, struct block_additio
     add_id = 1;
     data = NULL;
     has_data = 0;
+    data_size = 0;
     r = ne_read_element(ctx, &id, &size);
     if (r != 1)
       return r;


### PR DESCRIPTION
When building manually for iOS with Xcode, clang complains
about a possibly uninitialized data_size at the end of the
loop in ne_read_block_additions.

This is already safe because it's always initialized when
has_data is set to 1, and never used when has_data is left
at 0, but initializing data_size to 0 along with has_data
at the head of the loop silences the warning.

Should have no impact on functionality but keeps the compiler
happier.