### PR TITLE
Free previously read Block if we encounter another Block in the same …

### DIFF
--- a/src/nestegg.c
+++ b/src/nestegg.c
@@ -2815,6 +2815,11 @@ nestegg_read_packet(nestegg * ctx, nestegg_packet ** pkt)
 
         switch (id) {
         case ID_BLOCK: {
+          if (*pkt) {
+            ctx->log(ctx, NESTEGG_LOG_DEBUG,
+                     "read_packet: multiple Blocks in BlockGroup, dropping previously read Block");
+            nestegg_free_packet(*pkt);
+          }
           r = ne_read_block(ctx, id, size, pkt);
           if (r != 1) {
             ne_free_block_additions(block_additional);


### PR DESCRIPTION
…BlockGroup.

Fixes [BMO #1465651](https://bugzilla.mozilla.org/show_bug.cgi?id=1465651).

We originally assumed only a single Block occurs in a BlockGroup based on the
description of a BlockGroup from the Matroska specification: "Basic container
of information containing a single Block or BlockVirtual, and information
specific to that Block/VirtualBlock."

However, it turns out the spec also says "There can be many Blocks in a BlockGroup provided they all have the same timecode. It is used with different parts of a frame with different priorities." in the Block structure description.

So this change fixes the leak, but punts on correctly handling the (uncommon,
possibly never even used for WebM) case where multiple Blocks occur in a
BlockGroup.  If it turns out this case matters, we can revisit the fix.