### PR TITLE
Fix EOF handling in ne_buffer_read (used by nestegg_sniff).

### DIFF
--- a/src/nestegg.c
+++ b/src/nestegg.c
@@ -1960,17 +1960,18 @@ static int
 ne_buffer_read(void * buffer, size_t length, void * userdata)
 {
   struct io_buffer * iob = userdata;
-
-  int rv = 1;
   size_t available = iob->length - iob->offset;
 
-  if (available < length)
+  if (available == 0)
     return 0;
+
+  if (available < length)
+    return -1;
 
   memcpy(buffer, iob->buffer + iob->offset, length);
   iob->offset += length;
 
-  return rv;
+  return 1;
 }
 
 static int

--- a/test/fuzz.cc
+++ b/test/fuzz.cc
@@ -34,17 +34,18 @@ static int
 ne_buffer_read(void * buffer, size_t length, void * userdata)
 {
   struct io_buffer * iob = reinterpret_cast<struct io_buffer *>(userdata);
-
-  int rv = 1;
   size_t available = iob->length - iob->offset;
 
-  if (available < length)
+  if (available == 0)
     return 0;
+
+  if (available < length)
+    return -1;
 
   memcpy(buffer, iob->buffer + iob->offset, length);
   iob->offset += length;
 
-  return rv;
+  return 1;
 }
 
 static int


### PR DESCRIPTION
Previously, any short read would be treated as EOF.  Now, EOF is only
returned if the entire buffer has been consumed, and any short read is
signalled as an error.  This matches the expected behaviour of the
nestegg_io interface.

This code is duplicated in test/fuzz.cc, so also fixed there.

This addresses an OOM found by the oss-fuzz project (issue 8875).