### PR TITLE
Add an early frame size limit check to Xiph lacing parser.

### DIFF
--- a/src/nestegg.c
+++ b/src/nestegg.c
@@ -1360,6 +1360,9 @@ ne_read_xiph_lace_value(nestegg_io * io, uint64_t * value, size_t * consumed)
       return r;
     *consumed += 1;
     *value += lace;
+    /* Check frame size limit early to defeat crafted lace values. */
+    if (*value > LIMIT_FRAME)
+      return -1;
   }
 
   return 1;


### PR DESCRIPTION
A crafted file could trigger an unbounded number of I/O callbacks from the Xiph lacing parser.  Individual frames are already limited to LIMIT_FRAME, but this check is enforced after lacing is parsed.  Add an early LIMIT_FRAME check to the Xiph lacing parser to enforce an upper bound (~1M) on the number of I/O callbacks.